### PR TITLE
Improve neighbors interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,15 +213,8 @@ access will occur and the program will abort.
 
 The second function simply clears the grid by setting all pixels to zero.
 
-**`ge_neighbors_t ge_grid_get_neighbors8(const ge_grid_t* grid, ge_coord_t coord);`**<br>
-**`ge_neighbors_t ge_grid_get_neighbors8_wrapped(const ge_grid_t* grid, ge_coord_t coord);`**
-
-```
-typedef struct ge_neighbors {
-  size_t num_neighbors;
-  ge_coord_t neighbors[GE_MAX_NUM_NEIGHBORS];
-} ge_neighbors_t;
-```
+**`ge_neighbors_t ge_grid_get_neighbors(const ge_grid_t* grid, ge_coord_t coord);`**<br>
+**`ge_neighbors_t ge_grid_get_neighbors_wrapped(const ge_grid_t* grid, ge_coord_t coord);`**
 
 These functions return the coordinates of the neighbors of a pixel. The
 neighbors of a pixel are defined to be the eight pixels surrounding it. The

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ access will occur and the program will abort.
 
 The second function simply clears the grid by setting all pixels to zero.
 
-**`ge_neighbor_res_t ge_grid_get_neighbors(const ge_grid_t* grid, ge_coord_t coord);`**<br>
-**`ge_neighbor_res_t ge_grid_get_neighbors_wrapped(const ge_grid_t* grid, ge_coord_t coord);`**
+**`ge_neighbors_t ge_grid_get_neighbors8(const ge_grid_t* grid, ge_coord_t coord);`**<br>
+**`ge_neighbors_t ge_grid_get_neighbors8_wrapped(const ge_grid_t* grid, ge_coord_t coord);`**
 
 ```
-typedef struct ge_neighbor_res {
+typedef struct ge_neighbors {
   size_t num_neighbors;
   ge_coord_t neighbors[GE_MAX_NUM_NEIGHBORS];
-} ge_neighbor_res_t;
+} ge_neighbors_t;
 ```
 
 These functions return the coordinates of the neighbors of a pixel. The
@@ -316,10 +316,10 @@ the grid, and count the number of live neighboring cells:
 
 ```
       const bool is_live = (ge_grid_get_coord(grid, coord) != 0);
-      const ge_neighbor_res_t neighbor_res = ge_grid_get_neighbors_wrapped(grid, coord);
+      const ge_neighbors_t neighbors = ge_grid_get_neighbors_wrapped(grid, coord);
       size_t num_live_neighbors = 0;
-      for (size_t kk = 0; kk < neighbor_res.num_neighbors; ++kk) {
-        if (ge_grid_get_coord(grid, neighbor_res.neighbors[kk])) {
+      for (size_t kk = 0; kk < neighbors.num_neighbors; ++kk) {
+        if (ge_grid_get_coord(grid, neighbors.neighbors[kk])) {
           ++num_live_neighbors;
         }
       }

--- a/demos/demo_conway.c
+++ b/demos/demo_conway.c
@@ -50,10 +50,10 @@ void conway_loop_func(ge_grid_t* grid, void* user_data_, uint32_t time_ms)
     for (size_t ii = 0; ii < width; ++ii) {
       const ge_coord_t coord = (ge_coord_t){ii, jj};
       const bool is_live = (ge_grid_get_coord(grid, coord) != 0);
-      const ge_neighbor_res_t neighbor_res = ge_grid_get_neighbors_wrapped(grid, coord);
+      const ge_neighbors_t neighbors = ge_grid_get_neighbors8_wrapped(grid, coord);
       size_t num_live_neighbors = 0;
-      for (size_t kk = 0; kk < neighbor_res.num_neighbors; ++kk) {
-        if (ge_grid_get_coord(grid, neighbor_res.neighbors[kk])) {
+      for (size_t kk = 0; kk < neighbors.num_neighbors; ++kk) {
+        if (ge_grid_get_coord(grid, neighbors.neighbors[kk])) {
           ++num_live_neighbors;
         }
       }

--- a/demos/demo_conway.c
+++ b/demos/demo_conway.c
@@ -52,8 +52,9 @@ void conway_loop_func(ge_grid_t* grid, void* user_data_, uint32_t time_ms)
       const bool is_live = (ge_grid_get_coord(grid, coord) != 0);
       const ge_neighbors_t neighbors = ge_grid_get_neighbors_wrapped(grid, coord);
       size_t num_live_neighbors = 0;
-      for (size_t kk = 0; kk < GE_MAX_NUM_NEIGHBORS; kk = ge_neighbors_next_index(&neighbors, kk)) {
-        if (ge_grid_get_coord(grid, neighbors.neighbors[kk])) {
+      const ge_coord_t* neighbor_coord = NULL;
+      while ((neighbor_coord = ge_neighbors_next_coord(&neighbors, neighbor_coord)) != NULL) {
+        if (ge_grid_get_coord(grid, *neighbor_coord)) {
           ++num_live_neighbors;
         }
       }

--- a/demos/demo_conway.c
+++ b/demos/demo_conway.c
@@ -50,9 +50,9 @@ void conway_loop_func(ge_grid_t* grid, void* user_data_, uint32_t time_ms)
     for (size_t ii = 0; ii < width; ++ii) {
       const ge_coord_t coord = (ge_coord_t){ii, jj};
       const bool is_live = (ge_grid_get_coord(grid, coord) != 0);
-      const ge_neighbors_t neighbors = ge_grid_get_neighbors8_wrapped(grid, coord);
+      const ge_neighbors_t neighbors = ge_grid_get_neighbors_wrapped(grid, coord);
       size_t num_live_neighbors = 0;
-      for (size_t kk = 0; kk < neighbors.num_neighbors; ++kk) {
+      for (size_t kk = 0; kk < GE_MAX_NUM_NEIGHBORS; kk = ge_neighbors_next_index(&neighbors, kk)) {
         if (ge_grid_get_coord(grid, neighbors.neighbors[kk])) {
           ++num_live_neighbors;
         }

--- a/include/grid_engine/coord.h
+++ b/include/grid_engine/coord.h
@@ -36,5 +36,7 @@ ge_coord_t ge_coord_mul(ge_coord_t coord, ptrdiff_t scalar);
 ge_coord_t ge_coord_div(ge_coord_t coord, ptrdiff_t scalar);
 ge_coord_t ge_coord_clamp(ge_coord_t coord, size_t width, size_t height);
 ge_coord_t ge_coord_wrap(ge_coord_t coord, size_t width, size_t height);
+bool ge_coord_equals(ge_coord_t coord, ge_coord_t other_coord);
+bool ge_coord_is_invalid(ge_coord_t coord);
 
 #endif  // GE_COORD_H_

--- a/include/grid_engine/coord.h
+++ b/include/grid_engine/coord.h
@@ -21,6 +21,15 @@ typedef struct ge_coord {
   ptrdiff_t y;
 } ge_coord_t;
 
+// clang-format off
+#define GE_INVALID_COORD_K { \
+    .x = PTRDIFF_MIN, \
+    .y = PTRDIFF_MIN, \
+}
+// clang-format on
+
+extern const ge_coord_t GE_INVALID_COORD;
+
 ge_coord_t ge_coord_add(ge_coord_t coord, ge_coord_t other);
 ge_coord_t ge_coord_sub(ge_coord_t coord, ge_coord_t other);
 ge_coord_t ge_coord_mul(ge_coord_t coord, ptrdiff_t scalar);

--- a/include/grid_engine/grid.h
+++ b/include/grid_engine/grid.h
@@ -10,15 +10,9 @@
 #include <stdint.h>
 
 #include "grid_engine/coord.h"
-
-#define GE_MAX_NUM_NEIGHBORS 8
+#include "grid_engine/neighbors.h"
 
 typedef struct ge_grid ge_grid_t;
-
-typedef struct ge_neighbors {
-  size_t num_neighbors;
-  ge_coord_t neighbors[GE_MAX_NUM_NEIGHBORS];
-} ge_neighbors_t;
 
 ge_grid_t* ge_grid_create(size_t width, size_t height);
 void ge_grid_free(ge_grid_t* grid);
@@ -33,9 +27,7 @@ uint8_t ge_grid_get_coord(const ge_grid_t* grid, ge_coord_t coord);
 void ge_grid_set_coord(ge_grid_t* grid, ge_coord_t coord, uint8_t value);
 uint8_t ge_grid_get_coord_wrapped(const ge_grid_t* grid, ge_coord_t coord);
 void ge_grid_set_coord_wrapped(ge_grid_t* grid, ge_coord_t coord, uint8_t value);
-ge_neighbors_t ge_grid_get_neighbors4(const ge_grid_t* grid, ge_coord_t coord);
-ge_neighbors_t ge_grid_get_neighbors4_wrapped(const ge_grid_t* grid, ge_coord_t coord);
-ge_neighbors_t ge_grid_get_neighbors8(const ge_grid_t* grid, ge_coord_t coord);
-ge_neighbors_t ge_grid_get_neighbors8_wrapped(const ge_grid_t* grid, ge_coord_t coord);
+ge_neighbors_t ge_grid_get_neighbors(const ge_grid_t* grid, ge_coord_t coord);
+ge_neighbors_t ge_grid_get_neighbors_wrapped(const ge_grid_t* grid, ge_coord_t coord);
 
 #endif  // GE_GRID_H_

--- a/include/grid_engine/grid.h
+++ b/include/grid_engine/grid.h
@@ -15,10 +15,10 @@
 
 typedef struct ge_grid ge_grid_t;
 
-typedef struct ge_neighbor_res {
+typedef struct ge_neighbors {
   size_t num_neighbors;
   ge_coord_t neighbors[GE_MAX_NUM_NEIGHBORS];
-} ge_neighbor_res_t;
+} ge_neighbors_t;
 
 ge_grid_t* ge_grid_create(size_t width, size_t height);
 void ge_grid_free(ge_grid_t* grid);
@@ -33,7 +33,9 @@ uint8_t ge_grid_get_coord(const ge_grid_t* grid, ge_coord_t coord);
 void ge_grid_set_coord(ge_grid_t* grid, ge_coord_t coord, uint8_t value);
 uint8_t ge_grid_get_coord_wrapped(const ge_grid_t* grid, ge_coord_t coord);
 void ge_grid_set_coord_wrapped(ge_grid_t* grid, ge_coord_t coord, uint8_t value);
-ge_neighbor_res_t ge_grid_get_neighbors(const ge_grid_t* grid, ge_coord_t coord);
-ge_neighbor_res_t ge_grid_get_neighbors_wrapped(const ge_grid_t* grid, ge_coord_t coord);
+ge_neighbors_t ge_grid_get_neighbors4(const ge_grid_t* grid, ge_coord_t coord);
+ge_neighbors_t ge_grid_get_neighbors4_wrapped(const ge_grid_t* grid, ge_coord_t coord);
+ge_neighbors_t ge_grid_get_neighbors8(const ge_grid_t* grid, ge_coord_t coord);
+ge_neighbors_t ge_grid_get_neighbors8_wrapped(const ge_grid_t* grid, ge_coord_t coord);
 
 #endif  // GE_GRID_H_

--- a/include/grid_engine/neighbors.h
+++ b/include/grid_engine/neighbors.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Tim Perkins
+
+// Licensed under an MIT style license, see LICENSE.md for details.
+// You are free to copy and modify this code. Happy hacking!
+
+#ifndef GE_NEIGHBORS_H_
+#define GE_NEIGHBORS_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "grid_engine/coord.h"
+
+#define GE_MAX_NUM_NEIGHBORS 8
+
+typedef enum ge_direction {
+  GE_DIRECTION_NONE = -1,
+  GE_DIRECTION_NORTH = 0,
+  GE_DIRECTION_NORTHEAST,
+  GE_DIRECTION_EAST,
+  GE_DIRECTION_SOUTHEAST,
+  GE_DIRECTION_SOUTH,
+  GE_DIRECTION_SOUTHWEST,
+  GE_DIRECTION_WEST,
+  GE_DIRECTION_NORTHWEST,
+} ge_direction_t;
+
+typedef struct ge_neighbors {
+  ge_coord_t neighbors[GE_MAX_NUM_NEIGHBORS];
+} ge_neighbors_t;
+
+ge_neighbors_t ge_neighbors_from_coord(ge_coord_t coord);
+ge_neighbors_t ge_neighbors_from_coord_inside(ge_coord_t coord, size_t width, size_t height);
+ge_neighbors_t ge_neighbors_from_coord_wrapped(ge_coord_t coord, size_t width, size_t height);
+bool ge_neighbors_has_neighbor(const ge_neighbors_t* neighbors, ge_direction_t direction);
+ge_coord_t ge_neighbors_get_neighbor(const ge_neighbors_t* neighbors, ge_direction_t direction);
+size_t ge_neighbors_next_index(const ge_neighbors_t* neighbors, size_t index);
+ge_coord_t ge_neighbors_get_offset(ge_direction_t direction);
+
+#endif  // GE_NEIGHBORS_H_

--- a/include/grid_engine/neighbors.h
+++ b/include/grid_engine/neighbors.h
@@ -34,7 +34,29 @@ ge_neighbors_t ge_neighbors_from_coord_inside(ge_coord_t coord, size_t width, si
 ge_neighbors_t ge_neighbors_from_coord_wrapped(ge_coord_t coord, size_t width, size_t height);
 bool ge_neighbors_has_neighbor(const ge_neighbors_t* neighbors, ge_direction_t direction);
 ge_coord_t ge_neighbors_get_neighbor(const ge_neighbors_t* neighbors, ge_direction_t direction);
-size_t ge_neighbors_next_index(const ge_neighbors_t* neighbors, size_t index);
+
+/**
+ * Used to iterate through a set of neighboring coords. If `prev_coord` is
+ * `NULL`, this function will return the first coord in the set. If `prev_coord`
+ * is the last coord in the set, the result will be `NULL`. Intended to be used
+ * with a while loop, similarly to this:
+ *
+ * ```
+ * const ge_coord_t* nbr_coord = NULL;
+ * while ((nbr_coord = ge_neighbors_next_coord(&nbrs, nbr_coord)) != NULL) {
+ *   ...
+ * }
+ * ```
+ *
+ * @param neighbors The set of neighboring coords.
+ *
+ * @param prev_coord The previous coord, or `NULL` if there wasn't one.
+ *
+ * @return The next coord in the set, or `NULL` if there isn't one.
+ */
+const ge_coord_t* ge_neighbors_next_coord(const ge_neighbors_t* neighbors,
+                                          const ge_coord_t* prev_coord);
+
 ge_coord_t ge_neighbors_get_offset(ge_direction_t direction);
 
 #endif  // GE_NEIGHBORS_H_

--- a/src/coord.c
+++ b/src/coord.c
@@ -9,6 +9,8 @@ static ptrdiff_t pd_min(ptrdiff_t a, ptrdiff_t b);
 static ptrdiff_t pd_max(ptrdiff_t a, ptrdiff_t b);
 static ptrdiff_t pd_mod(ptrdiff_t a, ptrdiff_t b);
 
+const ge_coord_t GE_INVALID_COORD = GE_INVALID_COORD_K;
+
 ge_coord_t ge_coord_add(ge_coord_t coord, ge_coord_t other)
 {
   return (ge_coord_t){coord.x + other.x, coord.y + other.y};

--- a/src/coord.c
+++ b/src/coord.c
@@ -49,6 +49,16 @@ ge_coord_t ge_coord_wrap(ge_coord_t coord, size_t width, size_t height)
   };
 }
 
+bool ge_coord_equals(ge_coord_t coord, ge_coord_t other_coord)
+{
+  return (coord.x == other_coord.x && coord.y == other_coord.y);
+}
+
+bool ge_coord_is_invalid(ge_coord_t coord)
+{
+  return ge_coord_equals(coord, GE_INVALID_COORD);
+}
+
 static ptrdiff_t pd_min(ptrdiff_t a, ptrdiff_t b)
 {
   return (a < b ? a : b);

--- a/src/grid.c
+++ b/src/grid.c
@@ -18,11 +18,27 @@ typedef struct ge_grid {
 
 static void abort_on_out_of_bounds(const ge_grid_t* grid, ge_coord_t coord);
 
-static const ge_coord_t GE_NEIGHBOR_OFFSETS[GE_MAX_NUM_NEIGHBORS] = {
-    {-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1},
+// Counterclockwise around the unit circle, i.e., 0°, 90°, 180°, etc
+static const ge_coord_t GE_NEIGHBORS4_OFFSETS[4] = {
+    {1, 0},   //
+    {0, 1},   //
+    {-1, 0},  //
+    {0, -1},  //
 };
 
-static const ge_neighbor_res_t GE_NEIGHBOR_RES_DEFAULTS = {
+// Counterclockwise around the unit circle, i.e., 0°, 45°, 90°, etc
+static const ge_coord_t GE_NEIGHBORS8_OFFSETS[8] = {
+    {1, 0},    //
+    {1, 1},    //
+    {0, 1},    //
+    {-1, 1},   //
+    {-1, 0},   //
+    {-1, -1},  //
+    {0, -1},   //
+    {1, -1},   //
+};
+
+static const ge_neighbors_t GE_NEIGHBORS_DEFAULTS = {
     .num_neighbors = 0,
     .neighbors = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}},
 };
@@ -122,11 +138,11 @@ void ge_grid_set_coord_wrapped(ge_grid_t* grid, ge_coord_t coord, uint8_t value)
   ge_grid_set_coord(grid, coord, value);
 }
 
-ge_neighbor_res_t ge_grid_get_neighbors(const ge_grid_t* grid, ge_coord_t coord)
+ge_neighbors_t ge_grid_get_neighbors4(const ge_grid_t* grid, ge_coord_t coord)
 {
-  ge_neighbor_res_t result = GE_NEIGHBOR_RES_DEFAULTS;
-  for (size_t ii = 0; ii < GE_MAX_NUM_NEIGHBORS; ++ii) {
-    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBOR_OFFSETS[ii]);
+  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
+  for (size_t ii = 0; ii < 4; ++ii) {
+    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS4_OFFSETS[ii]);
     if (!ge_grid_has_coord(grid, nbr_coord)) {
       continue;
     }
@@ -135,11 +151,34 @@ ge_neighbor_res_t ge_grid_get_neighbors(const ge_grid_t* grid, ge_coord_t coord)
   return result;
 }
 
-ge_neighbor_res_t ge_grid_get_neighbors_wrapped(const ge_grid_t* grid, ge_coord_t coord)
+ge_neighbors_t ge_grid_get_neighbors4_wrapped(const ge_grid_t* grid, ge_coord_t coord)
 {
-  ge_neighbor_res_t result = GE_NEIGHBOR_RES_DEFAULTS;
-  for (size_t ii = 0; ii < GE_MAX_NUM_NEIGHBORS; ++ii) {
-    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBOR_OFFSETS[ii]);
+  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
+  for (size_t ii = 0; ii < 4; ++ii) {
+    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS4_OFFSETS[ii]);
+    result.neighbors[result.num_neighbors++] = ge_coord_wrap(nbr_coord, grid->width, grid->height);
+  }
+  return result;
+}
+
+ge_neighbors_t ge_grid_get_neighbors8(const ge_grid_t* grid, ge_coord_t coord)
+{
+  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
+  for (size_t ii = 0; ii < 8; ++ii) {
+    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS8_OFFSETS[ii]);
+    if (!ge_grid_has_coord(grid, nbr_coord)) {
+      continue;
+    }
+    result.neighbors[result.num_neighbors++] = nbr_coord;
+  }
+  return result;
+}
+
+ge_neighbors_t ge_grid_get_neighbors8_wrapped(const ge_grid_t* grid, ge_coord_t coord)
+{
+  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
+  for (size_t ii = 0; ii < 8; ++ii) {
+    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS8_OFFSETS[ii]);
     result.neighbors[result.num_neighbors++] = ge_coord_wrap(nbr_coord, grid->width, grid->height);
   }
   return result;

--- a/src/grid.c
+++ b/src/grid.c
@@ -18,31 +18,6 @@ typedef struct ge_grid {
 
 static void abort_on_out_of_bounds(const ge_grid_t* grid, ge_coord_t coord);
 
-// Counterclockwise around the unit circle, i.e., 0°, 90°, 180°, etc
-static const ge_coord_t GE_NEIGHBORS4_OFFSETS[4] = {
-    {1, 0},   //
-    {0, 1},   //
-    {-1, 0},  //
-    {0, -1},  //
-};
-
-// Counterclockwise around the unit circle, i.e., 0°, 45°, 90°, etc
-static const ge_coord_t GE_NEIGHBORS8_OFFSETS[8] = {
-    {1, 0},    //
-    {1, 1},    //
-    {0, 1},    //
-    {-1, 1},   //
-    {-1, 0},   //
-    {-1, -1},  //
-    {0, -1},   //
-    {1, -1},   //
-};
-
-static const ge_neighbors_t GE_NEIGHBORS_DEFAULTS = {
-    .num_neighbors = 0,
-    .neighbors = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}},
-};
-
 ge_grid_t* ge_grid_create(size_t width, size_t height)
 {
   ge_grid_t* grid = calloc(1, sizeof(ge_grid_t));
@@ -138,50 +113,16 @@ void ge_grid_set_coord_wrapped(ge_grid_t* grid, ge_coord_t coord, uint8_t value)
   ge_grid_set_coord(grid, coord, value);
 }
 
-ge_neighbors_t ge_grid_get_neighbors4(const ge_grid_t* grid, ge_coord_t coord)
+ge_neighbors_t ge_grid_get_neighbors(const ge_grid_t* grid, ge_coord_t coord)
 {
-  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
-  for (size_t ii = 0; ii < 4; ++ii) {
-    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS4_OFFSETS[ii]);
-    if (!ge_grid_has_coord(grid, nbr_coord)) {
-      continue;
-    }
-    result.neighbors[result.num_neighbors++] = nbr_coord;
-  }
-  return result;
+  abort_on_out_of_bounds(grid, coord);
+  return ge_neighbors_from_coord_inside(coord, grid->width, grid->height);
 }
 
-ge_neighbors_t ge_grid_get_neighbors4_wrapped(const ge_grid_t* grid, ge_coord_t coord)
+ge_neighbors_t ge_grid_get_neighbors_wrapped(const ge_grid_t* grid, ge_coord_t coord)
 {
-  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
-  for (size_t ii = 0; ii < 4; ++ii) {
-    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS4_OFFSETS[ii]);
-    result.neighbors[result.num_neighbors++] = ge_coord_wrap(nbr_coord, grid->width, grid->height);
-  }
-  return result;
-}
-
-ge_neighbors_t ge_grid_get_neighbors8(const ge_grid_t* grid, ge_coord_t coord)
-{
-  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
-  for (size_t ii = 0; ii < 8; ++ii) {
-    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS8_OFFSETS[ii]);
-    if (!ge_grid_has_coord(grid, nbr_coord)) {
-      continue;
-    }
-    result.neighbors[result.num_neighbors++] = nbr_coord;
-  }
-  return result;
-}
-
-ge_neighbors_t ge_grid_get_neighbors8_wrapped(const ge_grid_t* grid, ge_coord_t coord)
-{
-  ge_neighbors_t result = GE_NEIGHBORS_DEFAULTS;
-  for (size_t ii = 0; ii < 8; ++ii) {
-    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBORS8_OFFSETS[ii]);
-    result.neighbors[result.num_neighbors++] = ge_coord_wrap(nbr_coord, grid->width, grid->height);
-  }
-  return result;
+  abort_on_out_of_bounds(grid, coord);
+  return ge_neighbors_from_coord_wrapped(coord, grid->width, grid->height);
 }
 
 static void abort_on_out_of_bounds(const ge_grid_t* grid, ge_coord_t coord)

--- a/src/neighbors.c
+++ b/src/neighbors.c
@@ -1,0 +1,101 @@
+// Copyright (c) 2019 Tim Perkins
+
+// Licensed under an MIT style license, see LICENSE.md for details.
+// You are free to copy and modify this code. Happy hacking!
+
+#include "grid_engine/neighbors.h"
+
+#include <stdlib.h>
+
+#include "grid_engine/log.h"
+
+static void abort_on_invalid_coord(ge_coord_t coord);
+static bool coord_inside(ge_coord_t coord, size_t width, size_t height);
+
+static const ge_coord_t GE_NEIGHBOR_OFFSETS[GE_MAX_NUM_NEIGHBORS] = {
+    {0, -1}, {1, -1}, {1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}};
+
+static const ge_neighbors_t GE_NEIGHBORS_DEFAULTS = {
+    .neighbors =
+        {
+            GE_INVALID_COORD_K,
+            GE_INVALID_COORD_K,
+            GE_INVALID_COORD_K,
+            GE_INVALID_COORD_K,
+            GE_INVALID_COORD_K,
+            GE_INVALID_COORD_K,
+            GE_INVALID_COORD_K,
+            GE_INVALID_COORD_K,
+        },
+};
+
+ge_neighbors_t ge_neighbors_from_coord(ge_coord_t coord)
+{
+  ge_neighbors_t neighbors = GE_NEIGHBORS_DEFAULTS;
+  for (size_t ii = 0; ii < GE_MAX_NUM_NEIGHBORS; ++ii) {
+    neighbors.neighbors[ii] = ge_coord_add(coord, GE_NEIGHBOR_OFFSETS[ii]);
+  }
+  return neighbors;
+}
+
+ge_neighbors_t ge_neighbors_from_coord_inside(ge_coord_t coord, size_t width, size_t height)
+{
+  ge_neighbors_t neighbors = GE_NEIGHBORS_DEFAULTS;
+  for (size_t ii = 0; ii < GE_MAX_NUM_NEIGHBORS; ++ii) {
+    ge_coord_t nbr_coord = ge_coord_add(coord, GE_NEIGHBOR_OFFSETS[ii]);
+    if (!coord_inside(nbr_coord, width, height)) {
+      continue;
+    }
+    neighbors.neighbors[ii] = nbr_coord;
+  }
+  return neighbors;
+}
+
+ge_neighbors_t ge_neighbors_from_coord_wrapped(ge_coord_t coord, size_t width, size_t height)
+{
+  ge_neighbors_t neighbors = GE_NEIGHBORS_DEFAULTS;
+  for (size_t ii = 0; ii < GE_MAX_NUM_NEIGHBORS; ++ii) {
+    neighbors.neighbors[ii] =
+        ge_coord_wrap(ge_coord_add(coord, GE_NEIGHBOR_OFFSETS[ii]), width, height);
+  }
+  return neighbors;
+}
+
+bool ge_neighbors_has_neighbor(const ge_neighbors_t* neighbors, ge_direction_t direction)
+{
+  return !ge_coord_is_invalid(neighbors->neighbors[direction]);
+}
+
+ge_coord_t ge_neighbors_get_neighbor(const ge_neighbors_t* neighbors, ge_direction_t direction)
+{
+  abort_on_invalid_coord(neighbors->neighbors[direction]);
+  return neighbors->neighbors[direction];
+}
+
+size_t ge_neighbors_next_index(const ge_neighbors_t* neighbors, size_t index) {
+  for (++index; index < GE_MAX_NUM_NEIGHBORS; ++index) {
+    if (ge_neighbors_has_neighbor(neighbors, index)) {
+      break;
+    }
+  }
+  return index;
+}
+
+ge_coord_t ge_neighbors_get_offset(ge_direction_t direction)
+{
+  return GE_NEIGHBOR_OFFSETS[direction];
+}
+
+static void abort_on_invalid_coord(ge_coord_t coord)
+{
+  if (ge_coord_is_invalid(coord)) {
+    GE_LOG_ERROR("Coord is invalid!");
+    abort();
+  }
+}
+
+static bool coord_inside(ge_coord_t coord, size_t width, size_t height)
+{
+  return (coord.x >= 0 && coord.x < (ptrdiff_t) width && coord.y >= 0
+          && coord.y < (ptrdiff_t) height);
+}

--- a/src/neighbors.c
+++ b/src/neighbors.c
@@ -72,13 +72,16 @@ ge_coord_t ge_neighbors_get_neighbor(const ge_neighbors_t* neighbors, ge_directi
   return neighbors->neighbors[direction];
 }
 
-size_t ge_neighbors_next_index(const ge_neighbors_t* neighbors, size_t index) {
-  for (++index; index < GE_MAX_NUM_NEIGHBORS; ++index) {
-    if (ge_neighbors_has_neighbor(neighbors, index)) {
-      break;
-    }
+const ge_coord_t* ge_neighbors_next_coord(const ge_neighbors_t* neighbors,
+                                          const ge_coord_t* prev_coord)
+{
+  const ge_coord_t* const begin_coord = neighbors->neighbors;
+  const ge_coord_t* const end_coord = neighbors->neighbors + GE_MAX_NUM_NEIGHBORS;
+  const ge_coord_t* coord = (prev_coord == NULL ? begin_coord : prev_coord + 1);
+  while (coord < end_coord && ge_coord_is_invalid(*coord)) {
+    ++prev_coord;
   }
-  return index;
+  return (coord != end_coord ? coord : NULL);
 }
 
 ge_coord_t ge_neighbors_get_offset(ge_direction_t direction)


### PR DESCRIPTION
Rework functions to get neighbor coords, to check for their existence, and to iterate over them. Also added a special invalid coord constant, to indicate that there is no result without having to introduce pointers and a null check.