### PR TITLE
Grid operations for copy and blit

### DIFF
--- a/include/grid_engine/grid.h
+++ b/include/grid_engine/grid.h
@@ -11,6 +11,7 @@
 
 #include "grid_engine/coord.h"
 #include "grid_engine/nbrs.h"
+#include "grid_engine/rect.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,6 +23,7 @@ ge_grid_t* ge_grid_create(size_t width, size_t height);
 void ge_grid_free(ge_grid_t* grid);
 size_t ge_grid_get_width(const ge_grid_t* grid);
 size_t ge_grid_get_height(const ge_grid_t* grid);
+ge_rect_t ge_grid_get_rect(const ge_grid_t* grid);
 const uint8_t* ge_grid_get_pixel_arr(const ge_grid_t* grid);
 uint8_t* ge_grid_get_pixel_arr_mut(ge_grid_t* grid);
 void ge_grid_copy_pixel_arr(ge_grid_t* grid, const ge_grid_t* other);
@@ -33,6 +35,8 @@ uint8_t ge_grid_get_coord_wrapped(const ge_grid_t* grid, ge_coord_t coord);
 void ge_grid_set_coord_wrapped(ge_grid_t* grid, ge_coord_t coord, uint8_t value);
 ge_nbrs_t ge_grid_get_nbrs(const ge_grid_t* grid, ge_coord_t coord);
 ge_nbrs_t ge_grid_get_nbrs_wrapped(const ge_grid_t* grid, ge_coord_t coord);
+ge_grid_t* ge_grid_copy_rect(const ge_grid_t* grid, ge_rect_t rect);
+void ge_grid_blit(ge_grid_t* grid, const ge_grid_t* blit_grid, ge_coord_t coord);
 
 #ifdef __cplusplus
 }

--- a/include/grid_engine/rect.h
+++ b/include/grid_engine/rect.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Tim Perkins
+
+// Licensed under an MIT style license, see LICENSE.md for details.
+// You are free to copy and modify this code. Happy hacking!
+
+#ifndef GE_RECT_H_
+#define GE_RECT_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "grid_engine/coord.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Represents a rectangle, i.e., an Axis Aligned Bounding Box (AABB), using a
+ * minimum and maximum corner coord. The minimum coord is inclusive, and the
+ * maximum coord is exclusive.
+ */
+typedef struct ge_rect {
+  ge_coord_t min_coord;
+  ge_coord_t max_coord;
+} ge_rect_t;
+
+#define GE_INVALID_RECT_K                                             \
+  {                                                                   \
+    .min_coord = GE_INVALID_COORD_K, .max_coord = GE_INVALID_COORD_K, \
+  }
+
+extern const ge_rect_t GE_INVALID_RECT;
+
+ge_rect_t ge_rect_from_wh(size_t width, size_t height);
+ge_rect_t ge_rect_from_coord_wh(ge_coord_t coord, size_t width, size_t height);
+size_t ge_rect_get_width(ge_rect_t rect);
+size_t ge_rect_get_height(ge_rect_t rect);
+ge_rect_t ge_rect_add(ge_rect_t rect, ge_coord_t coord);
+ge_rect_t ge_rect_sub(ge_rect_t rect, ge_coord_t coord);
+ge_rect_t ge_rect_overlap(ge_rect_t rect, ge_rect_t other);
+ge_rect_t ge_rect_clamp_rect(ge_rect_t rect, ge_rect_t other);
+ge_coord_t ge_rect_clamp_coord(ge_rect_t rect, ge_coord_t coord);
+bool ge_rect_equals(ge_rect_t rect, ge_rect_t other);
+bool ge_rect_is_invalid(ge_rect_t rect);
+bool ge_rect_within_rect(ge_rect_t rect, ge_rect_t other);
+bool ge_rect_within_coord(ge_rect_t rect, ge_coord_t coord);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // GE_RECT_H_

--- a/src/grid.c
+++ b/src/grid.c
@@ -53,6 +53,11 @@ size_t ge_grid_get_height(const ge_grid_t* grid)
   return grid->height;
 }
 
+ge_rect_t ge_grid_get_rect(const ge_grid_t* grid)
+{
+  return ge_rect_from_wh(grid->width, grid->height);
+}
+
 const uint8_t* ge_grid_get_pixel_arr(const ge_grid_t* grid)
 {
   return grid->pixel_arr;
@@ -123,6 +128,46 @@ ge_nbrs_t ge_grid_get_nbrs_wrapped(const ge_grid_t* grid, ge_coord_t coord)
 {
   abort_on_out_of_bounds(grid, coord);
   return ge_nbrs_from_coord_wrapped(coord, grid->width, grid->height);
+}
+
+ge_grid_t* ge_grid_copy_rect(const ge_grid_t* grid, ge_rect_t rect)
+{
+  // Check that the rect is actually within the grid
+  const ge_rect_t grid_rect = ge_grid_get_rect(grid);
+  if (!ge_rect_within_rect(grid_rect, rect)) {
+    return NULL;
+  }
+  // Create the grid and copy data
+  const size_t width = ge_rect_get_width(rect);
+  const size_t height = ge_rect_get_height(rect);
+  ge_grid_t* const copy_grid = ge_grid_create(width, height);
+  for (size_t jj = 0; jj < height; ++jj) {
+    uint8_t* const src_pixel_row =
+        grid->pixel_arr + (grid->width * (jj + rect.min_coord.y)) + rect.min_coord.x;
+    uint8_t* const dest_pixel_row = copy_grid->pixel_arr + (width * jj);
+    memcpy(dest_pixel_row, src_pixel_row, width);
+  }
+  return copy_grid;
+}
+
+void ge_grid_blit(ge_grid_t* grid, const ge_grid_t* blit_grid, ge_coord_t coord)
+{
+  // Get rect overlapping the grid
+  const ge_rect_t grid_rect = ge_grid_get_rect(grid);
+  const ge_rect_t blit_grid_rect = ge_rect_add(ge_grid_get_rect(blit_grid), coord);
+  const ge_rect_t overlap_rect = ge_rect_overlap(grid_rect, blit_grid_rect);
+  const ge_rect_t blit_rect = ge_rect_sub(overlap_rect, coord);
+  const size_t blit_width = ge_rect_get_width(blit_rect);
+  const size_t blit_height = ge_rect_get_height(blit_rect);
+  for (size_t jj = 0; jj < blit_height; ++jj) {
+    uint8_t* const src_pixel_row =
+        (blit_grid->pixel_arr + (blit_grid->width * (jj + blit_rect.min_coord.y))
+         + blit_rect.min_coord.x);
+    uint8_t* const dest_pixel_row =
+        (grid->pixel_arr + (grid->width * (jj + overlap_rect.min_coord.y))
+         + overlap_rect.min_coord.x);
+    memcpy(dest_pixel_row, src_pixel_row, blit_width);
+  }
 }
 
 static void abort_on_out_of_bounds(const ge_grid_t* grid, ge_coord_t coord)

--- a/src/rect.c
+++ b/src/rect.c
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 Tim Perkins
+
+// Licensed under an MIT style license, see LICENSE.md for details.
+// You are free to copy and modify this code. Happy hacking!
+
+#include "grid_engine/rect.h"
+
+static ptrdiff_t pd_min(ptrdiff_t a, ptrdiff_t b);
+static ptrdiff_t pd_max(ptrdiff_t a, ptrdiff_t b);
+
+const ge_rect_t GE_INVALID_RECT = GE_INVALID_RECT_K;
+
+ge_rect_t ge_rect_from_wh(size_t width, size_t height)
+{
+  return (ge_rect_t){
+      (ge_coord_t){0, 0},
+      (ge_coord_t){width, height},
+  };
+}
+
+ge_rect_t ge_rect_from_coord_wh(ge_coord_t coord, size_t width, size_t height)
+{
+  return (ge_rect_t){
+      coord,
+      ge_coord_add(coord, (ge_coord_t){width, height}),
+  };
+}
+
+size_t ge_rect_get_width(ge_rect_t rect)
+{
+  return rect.max_coord.x - rect.min_coord.x;
+}
+
+size_t ge_rect_get_height(ge_rect_t rect)
+{
+  return rect.max_coord.y - rect.min_coord.y;
+}
+
+ge_rect_t ge_rect_add(ge_rect_t rect, ge_coord_t coord)
+{
+  return (ge_rect_t){
+      ge_coord_add(rect.min_coord, coord),
+      ge_coord_add(rect.max_coord, coord),
+  };
+}
+
+ge_rect_t ge_rect_sub(ge_rect_t rect, ge_coord_t coord)
+{
+  return (ge_rect_t){
+      ge_coord_sub(rect.min_coord, coord),
+      ge_coord_sub(rect.max_coord, coord),
+  };
+}
+
+ge_rect_t ge_rect_overlap(ge_rect_t rect, ge_rect_t other)
+{
+  return (ge_rect_t){
+      (ge_coord_t){
+          pd_max(rect.min_coord.x, other.min_coord.x),
+          pd_max(rect.min_coord.y, other.min_coord.y),
+      },
+      (ge_coord_t){
+          pd_min(rect.max_coord.x, other.max_coord.x),
+          pd_min(rect.max_coord.y, other.max_coord.y),
+      },
+  };
+}
+
+ge_rect_t ge_rect_clamp_rect(ge_rect_t rect, ge_rect_t other)
+{
+  // Clamp each coorner of the other rect to be within this rect
+  return (ge_rect_t){
+      (ge_coord_t){
+          pd_max(rect.min_coord.x, pd_min(other.min_coord.x, rect.max_coord.x)),
+          pd_max(rect.min_coord.y, pd_min(other.min_coord.y, rect.max_coord.y)),
+      },
+      (ge_coord_t){
+          pd_max(rect.min_coord.x, pd_min(other.max_coord.x, rect.max_coord.x)),
+          pd_max(rect.min_coord.y, pd_min(other.max_coord.y, rect.max_coord.y)),
+      },
+  };
+}
+
+ge_coord_t ge_rect_clamp_coord(ge_rect_t rect, ge_coord_t coord)
+{
+  // Make sure the rect does not have zero width or height
+  if (rect.min_coord.x == rect.max_coord.x || rect.min_coord.y == rect.max_coord.y) {
+    return GE_INVALID_COORD;
+  }
+  // When we clamp coords, remember that the max coord is exclusive
+  return (ge_coord_t){
+      pd_max(rect.min_coord.x, pd_min(coord.x, rect.max_coord.x - 1)),
+      pd_max(rect.min_coord.y, pd_min(coord.y, rect.max_coord.y - 1)),
+  };
+}
+
+bool ge_rect_equals(ge_rect_t rect, ge_rect_t other)
+{
+  return (ge_coord_equals(rect.min_coord, other.min_coord)
+          && ge_coord_equals(rect.max_coord, other.max_coord));
+}
+
+bool ge_rect_is_invalid(ge_rect_t rect)
+{
+  return (ge_coord_is_invalid(rect.min_coord) || ge_coord_is_invalid(rect.max_coord));
+}
+
+bool ge_rect_within_rect(ge_rect_t rect, ge_rect_t other)
+{
+  return ((rect.min_coord.x <= other.min_coord.x && other.min_coord.x <= rect.max_coord.x)
+          && (rect.min_coord.y <= other.min_coord.y && other.min_coord.y <= rect.max_coord.y)
+          && (rect.min_coord.x <= other.max_coord.x && other.max_coord.x <= rect.max_coord.x)
+          && (rect.min_coord.y <= other.max_coord.y && other.max_coord.y <= rect.max_coord.y));
+}
+
+bool ge_rect_within_coord(ge_rect_t rect, ge_coord_t coord)
+{
+  // When checking coords, remember that the max coord is exclusive
+  return ((rect.min_coord.x <= coord.x && coord.x < rect.max_coord.x)
+          && (rect.min_coord.y <= coord.y && coord.y < rect.max_coord.y));
+}
+
+static ptrdiff_t pd_min(ptrdiff_t a, ptrdiff_t b)
+{
+  return (a < b ? a : b);
+}
+
+static ptrdiff_t pd_max(ptrdiff_t a, ptrdiff_t b)
+{
+  return (a > b ? a : b);
+}


### PR DESCRIPTION
Adds copy and blit operations on grids. Also adds basic rectangle (AABB) utility code.

Blits don't support transparency yet. This should be improved, probably by using masking.